### PR TITLE
Fix versioning with GitHub action

### DIFF
--- a/.github/workflows/d4l-ci-latest-version.yml
+++ b/.github/workflows/d4l-ci-latest-version.yml
@@ -21,9 +21,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - run: git branch -D ${{ github.head_ref }} || true
-      - name: Reattach head
-        run: git checkout -b ${{ github.head_ref }}
       - name: Cleanup
         run: ./gradlew clean
       - name: Version

--- a/.github/workflows/d4l-ci-publish-release.yml
+++ b/.github/workflows/d4l-ci-publish-release.yml
@@ -20,9 +20,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - run: git branch -D ${{ github.head_ref }} || true
-      - name: Reattach head
-        run: git checkout -b ${{ github.head_ref }}
       - name: Cleanup
         run: ./gradlew clean
       - name: Version

--- a/.github/workflows/d4l-ci-pull-request-validation.yml
+++ b/.github/workflows/d4l-ci-pull-request-validation.yml
@@ -22,9 +22,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - run: git branch -D ${{ github.head_ref }} || true
-      - name: Reattach head
-        run: git checkout -b ${{ github.head_ref }}
+          ref: ${{ github.head_ref }}
       - name: Cleanup
         run: ./gradlew clean
       - name: Version

--- a/buildSrc/src/main/kotlin/scripts/publishing-config.gradle.kts
+++ b/buildSrc/src/main/kotlin/scripts/publishing-config.gradle.kts
@@ -37,7 +37,7 @@ publishing {
             }
         }
 
-        val target = "file://${project.buildDir}/gitPublish"
+        val target = "file://${project.rootProject.buildDir}/gitPublish"
 
         maven {
             name = "ReleasePackages"

--- a/buildSrc/src/main/kotlin/scripts/versioning.gradle.kts
+++ b/buildSrc/src/main/kotlin/scripts/versioning.gradle.kts
@@ -28,6 +28,7 @@ fun versionName(): String {
     val details = versionDetails()
 
     return when {
+        details.branchName == null -> versionNameWithQualifier(details)
         patternNoQualifierBranch.matches(details.branchName) -> versionNameWithQualifier(details)
         patternFeatureBranch.matches(details.branchName) -> versionNameFeature(details)
         else -> throw UnsupportedOperationException("branch name not supported: ${details.branchName}")
@@ -44,7 +45,10 @@ fun versionNameFeature(details: com.palantir.gradle.gitversion.VersionDetails): 
     return versionNameWithQualifier(details, featureName)
 }
 
-fun versionNameWithQualifier(details: com.palantir.gradle.gitversion.VersionDetails, name: String = ""): String {
+fun versionNameWithQualifier(
+    details: com.palantir.gradle.gitversion.VersionDetails,
+    name: String = ""
+): String {
     val version = if (!details.isCleanTag) {
         var versionCleaned = details.version.substringBefore(".dirty")
         if (details.commitDistance > 0) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,12 +12,12 @@
 #
 # Gradle
 org.gradle.jvmargs=-Xmx1536m
-org.gradle.parallel=true
+org.gradle.parallel=false
 # Kotlin
 kotlin.incremental.multiplatform=true
 kotlin.parallel.tasks.in.project=true
-kotlin.code.style=official
 kotlin.mpp.stability.nowarn=true
+kotlin.code.style=official
 # Android
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
## Description

Change the CI Jobs to properly generate versions based on the job executed

- Remove reattach head from latest job as we are already on a branch either main or release/*
- Change publish job by removing reattach head and patching the versioning script to allow the branch name to be null, as we only need the tag
-  Change pull-request validation job to use the branch reference and remove custom checkout

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated the changelog accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
