### PR TITLE
Bump D4L FHIR SDK 1.1.0 -> 1.2.1

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -24,9 +24,11 @@ toc::[]
 
 === Bumped
 
-* D4L FHIR SDK 1.1.0 -> 1.2.1
+* **_BREAKING_** D4L FHIR SDK 1.1.0 -> 1.2.1
 
 === Migration
+
+D4L FHIR SDK 1.2.0 introduces breaking changes, see link:https://github.com/d4l-data4life/hc-fhir-sdk-java/releases/tag/v1.2.0[1.2.0]
 
 
 == https://github.com/d4l-data4life/hc-fhir-helper-sdk-kmp/compare/v1.4.1...v1.5.0[1.5.0]

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -24,6 +24,8 @@ toc::[]
 
 === Bumped
 
+* D4L FHIR SDK 1.1.0 -> 1.2.1
+
 === Migration
 
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -101,7 +101,7 @@ object Dependencies {
 
     val d4l = D4L
     object D4L {
-        val fhirJvm = "care.data4life.hc-fhir-sdk-java:hc-fhir-sdk-java:${Versions.fhir}"
+        val fhirJvm = "care.data4life.hc-fhir-sdk-java:fhir-java:${Versions.fhir}"
 
         val utilCommon = "care.data4life.hc-util-sdk-kmp:util:${Versions.sdkUtil}"
         val utilAndroid = "care.data4life.hc-util-sdk-kmp:util-android:${Versions.sdkUtil}"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -76,7 +76,7 @@ object Versions {
     /**
      * [hc-fhir-sdk-java](https://github.com/d4l-data4life/hc-fhir-sdk-java)
      */
-    const val fhir = "1.1.0"
+    const val fhir = "1.2.1"
 
     /**
      * [hc-util-sdk-kmp](https://github.com/d4l-data4life/hc-util-sdk-kmp)


### PR DESCRIPTION
## Description
Update FHIR SDK 1.1.0 to [1.2.1](https://github.com/d4l-data4life/hc-fhir-sdk-java/releases/tag/v1.2.1)

This is a BREAKING change see [1.2.0](https://github.com/d4l-data4life/hc-fhir-sdk-java/releases/tag/v1.2.0)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the changelog accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
