### PR TITLE
Change publishing

### DIFF
--- a/.github/workflows/d4l-ci-pull-request-precheck.yml
+++ b/.github/workflows/d4l-ci-pull-request-precheck.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Danger
-        uses: danger/kotlin@1.0.0-beta
+        uses: docker://ghcr.io/danger/danger-kotlin:1.0.0-beta
+        with:
+          args: --failOnErrors --no-publish-check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -28,6 +28,7 @@ toc::[]
 
 * **_BREAKING_** D4L FHIR SDK 1.1.0 -> 1.2.1
 * Bump Gradle 6.7.1 -> 6.8.3
+* Android Gradle Plugin 4.1.1 -> 4.1.3
 
 === Migration
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -27,6 +27,7 @@ toc::[]
 === Bumped
 
 * **_BREAKING_** D4L FHIR SDK 1.1.0 -> 1.2.1
+* Bump Gradle 6.7.1 -> 6.8.3
 
 === Migration
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,6 @@ buildscript {
     dependencies {
         classpath(GradlePlugins.android)
         classpath(GradlePlugins.kotlin)
-        classpath(GradlePlugins.gitPublish)
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,6 @@ buildscript {
         mavenCentral()
         google()
         jcenter()
-        maven("https://dl.bintray.com/data4life/maven")
     }
     dependencies {
         classpath(GradlePlugins.android)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,6 +68,6 @@ allprojects {
 }
 
 tasks.named<Wrapper>("wrapper") {
-    gradleVersion = "6.7.1"
+    gradleVersion = "6.8.3"
     distributionType = Wrapper.DistributionType.ALL
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -21,7 +21,6 @@ plugins {
 repositories {
     gradlePluginPortal()
     mavenCentral()
-    maven("https://dl.bintray.com/data4life/maven")
 }
 
 dependencies {
@@ -30,7 +29,7 @@ dependencies {
     // download scripts
     implementation("de.undercouch:gradle-download-task:4.1.1")
     // publishing.gradle.kts
-    implementation("care.data4life:gradle-git-publish:3.2.0")
+    implementation("org.eclipse.jgit:org.eclipse.jgit:5.11.0.202103091610-r")
     // quality.gradle.kts
     implementation("com.diffplug.spotless:spotless-plugin-gradle:5.10.2")
     implementation("com.pinterest:ktlint:0.41.0")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
     implementation("care.data4life:gradle-git-publish:3.2.0")
     // quality.gradle.kts
     implementation("com.diffplug.spotless:spotless-plugin-gradle:5.10.2")
-    implementation("com.pinterest:ktlint:0.40.0")
+    implementation("com.pinterest:ktlint:0.41.0")
     // versioning.gradle.kts
     implementation("com.palantir.gradle.gitversion:gradle-git-version:0.12.3")
 }

--- a/buildSrc/src/main/kotlin/GradlePlugins.kt
+++ b/buildSrc/src/main/kotlin/GradlePlugins.kt
@@ -20,7 +20,6 @@ import org.gradle.plugin.use.PluginDependencySpec
 object GradlePlugins {
     const val android = "com.android.tools.build:gradle:${Versions.GradlePlugins.android}"
     const val kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.GradlePlugins.kotlin}"
-    const val gitPublish = "care.data4life:gradle-git-publish:${Versions.GradlePlugins.gitPublish}"
 }
 
 fun PluginDependenciesSpec.kotlinMultiplatform(apply: Boolean = true): PluginDependencySpec =

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -18,7 +18,7 @@ object Versions {
 
     object GradlePlugins {
         const val kotlin = Versions.kotlin
-        const val android = "4.1.1"
+        const val android = "4.1.3"
 
         /**
          * [jGitVer](https://github.com/jgitver/gradle-jgitver-plugin)

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -19,16 +19,6 @@ object Versions {
     object GradlePlugins {
         const val kotlin = Versions.kotlin
         const val android = "4.1.3"
-
-        /**
-         * [jGitVer](https://github.com/jgitver/gradle-jgitver-plugin)
-         */
-        const val gitVersioning = "0.6.1"
-
-        /**
-         * [Gradle Git Publish](https://github.com/d4l-data4life/gradle-git-publish)
-         */
-        const val gitPublish = "3.2.0"
     }
 
     // Kotlin

--- a/buildSrc/src/main/kotlin/scripts/publishing-config.gradle.kts
+++ b/buildSrc/src/main/kotlin/scripts/publishing-config.gradle.kts
@@ -56,17 +56,17 @@ publishing {
 
         maven {
             name = "ReleasePackages"
-            setUrl("$target/releases")
+            setUrl("$target/maven-releases/releases")
         }
 
         maven {
             name = "SnapshotPackages"
-            setUrl("$target/snapshots")
+            setUrl("$target/maven-snapshots/snapshots")
         }
 
         maven {
             name = "FeaturePackages"
-            setUrl("$target/features")
+            setUrl("$target/maven-features/features")
         }
     }
 

--- a/buildSrc/src/main/kotlin/scripts/publishing.gradle.kts
+++ b/buildSrc/src/main/kotlin/scripts/publishing.gradle.kts
@@ -17,7 +17,11 @@
 package scripts
 
 import LibraryConfig
-import org.gradle.api.tasks.Exec
+import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.api.ResetCommand
+import org.eclipse.jgit.transport.PushResult
+import org.eclipse.jgit.transport.RemoteRefUpdate
+import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider
 
 /**
  * Usage:
@@ -25,13 +29,13 @@ import org.gradle.api.tasks.Exec
  * You need to add following dependencies to the buildSrc/build.gradle.kts
  *
  * dependencies {
- *     implementation("care.data4life:gradle-git-publish:3.2.0")
+ *     implementation("org.eclipse.jgit:org.eclipse.jgit:5.11.0.202103091610-r")
  * }
  *
- * and ensure that the gradlePluginPortal is available
+ * and ensure that the mavenCentral repository is available
  *
  * repositories {
- *     gradlePluginPortal()
+ *     mavenCentral()
  * }
  *
  * Now just add id("scripts.publishing") to your rootProject build.gradle.kts plugins
@@ -40,63 +44,186 @@ import org.gradle.api.tasks.Exec
  *     id("scripts.publishing")
  * }
  *
- * To publish to to https://github.com/d4l-data4life/maven-repository/ just run:
+ * To publish to to https://github.com/d4l-data4life/maven-features/ just run:
  * - ./gradlew publishFeature
+ * To publish to to https://github.com/d4l-data4life/maven-snapshots/ just run:
  * - ./gradlew publishSnapshot
+ * To publish to to https://github.com/d4l-data4life/maven-releases/ just run:
  * - ./gradlew publishRelease
  *
  * This requires publishing-config.gradle.kts!
  */
-plugins {
-    id("care.data4life.git-publish")
-}
 
-afterEvaluate {
-    configure<care.data4life.gradle.git.publish.GitPublishExtension> {
-        repoUri.set("git@github.com:d4l-data4life/maven-repository.git")
+val taskGroup = "publishing"
 
-        branch.set("main")
+val featureRepoName = "maven-features"
+val snapshotRepoName = "maven-snapshots"
+val releaseRepoName = "maven-releases"
 
-        contents {
-        }
+val basePath = "${rootProject.buildDir}/gitPublish"
 
-        preserve {
-            include("**/*")
-        }
+val gitHubToken = (project.findProperty("gpr.key")
+    ?: System.getenv("PACKAGE_REGISTRY_TOKEN")).toString()
 
-        commitMessage.set("Publish ${LibraryConfig.name} ${project.version}")
-    }
-}
 
 task<Exec>("publishFeature") {
-    group = "publishing"
+    group = taskGroup
 
-    commandLine("./gradlew",
-            "gitPublishReset",
-            "publishAllPublicationsToFeaturePackagesRepository",
-            "gitPublishCommit",
-            "gitPublishPush"
+    commandLine(
+        "./gradlew",
+        "gitPublishFeatureCheckout",
+        "gitPublishFeatureUpdate",
+        "publishAllPublicationsToFeaturePackagesRepository",
+        "gitPublishFeatureCommit",
+        "gitPublishFeaturePush"
     )
 }
 
 task<Exec>("publishSnapshot") {
-    group = "publishing"
+    group = taskGroup
 
-    commandLine("./gradlew",
-            "gitPublishReset",
-            "publishAllPublicationsToSnapshotPackagesRepository",
-            "gitPublishCommit",
-            "gitPublishPush"
+    commandLine(
+        "./gradlew",
+        "gitPublishSnapshotCheckout",
+        "gitPublishSnapshotUpdate",
+        "publishAllPublicationsToSnapshotPackagesRepository",
+        "gitPublishSnapshotCommit",
+        "gitPublishSnapshotPush"
     )
 }
 
 task<Exec>("publishRelease") {
-    group = "publishing"
+    group = taskGroup
 
-    commandLine("./gradlew",
-            "gitPublishReset",
-            "publishAllPublicationsToReleasePackagesRepository",
-            "gitPublishCommit",
-            "gitPublishPush"
+    commandLine(
+        "./gradlew",
+        "gitPublishReleaseCheckout",
+        "gitPublishReleaseUpdate",
+        "publishAllPublicationsToReleasePackagesRepository",
+        "gitPublishReleaseCommit",
+        "gitPublishReleasePush"
     )
+}
+
+// Git Checkout
+val gitPublishFeatureCheckout: Task by tasks.creating() {
+    group = taskGroup
+    doLast { gitClone(featureRepoName) }
+}
+
+val gitPublishSnapshotCheckout: Task by tasks.creating() {
+    group = taskGroup
+    doLast { gitClone(snapshotRepoName) }
+}
+
+val gitPublishReleaseCheckout: Task by tasks.creating() {
+    group = taskGroup
+    doLast { gitClone(releaseRepoName) }
+}
+
+// Git Update
+val gitPublishFeatureUpdate: Task by tasks.creating() {
+    group = taskGroup
+    doLast { gitUpdate(featureRepoName) }
+}
+
+val gitPublishSnapshotUpdate: Task by tasks.creating() {
+    group = taskGroup
+    doLast { gitUpdate(snapshotRepoName) }
+}
+
+val gitPublishReleaseUpdate: Task by tasks.creating() {
+    group = taskGroup
+    doLast { gitUpdate(releaseRepoName) }
+}
+
+// Git Commit
+val gitPublishFeatureCommit: Task by tasks.creating() {
+    group = taskGroup
+    doLast { gitCommit(featureRepoName) }
+}
+
+val gitPublishSnapshotCommit: Task by tasks.creating() {
+    group = taskGroup
+    doLast { gitCommit(snapshotRepoName) }
+}
+
+val gitPublishReleaseCommit: Task by tasks.creating() {
+    group = taskGroup
+    doLast { gitCommit(releaseRepoName) }
+}
+
+// Git Push
+val gitPublishFeaturePush: Task by tasks.creating() {
+    group = taskGroup
+    doLast { gitPush(featureRepoName) }
+}
+
+val gitPublishSnapshotPush: Task by tasks.creating() {
+    group = taskGroup
+    doLast { gitPush(snapshotRepoName) }
+}
+
+val gitPublishReleasePush: Task by tasks.creating() {
+    group = taskGroup
+    doLast { gitPush(releaseRepoName) }
+}
+
+// Git calls
+fun gitClone(repositoryName: String) {
+    try {
+        gitUpdate(repositoryName)
+    } catch (exception: Exception) {
+        Git.cloneRepository()
+            .setURI("https://github.com/d4l-data4life/$repositoryName.git")
+            .setCredentialsProvider(UsernamePasswordCredentialsProvider(gitHubToken, ""))
+            .setDirectory(File("$basePath/$repositoryName"))
+            .call()
+    }
+}
+
+fun gitUpdate(repositoryName: String) {
+    val git = Git.open(File("$basePath/$repositoryName"))
+
+    git.fetch()
+        .setForceUpdate(true)
+        .setCredentialsProvider(UsernamePasswordCredentialsProvider(gitHubToken, ""))
+        .call()
+
+    git.reset()
+        .setMode(ResetCommand.ResetType.HARD)
+        .setRef("origin/main")
+        .call()
+}
+
+fun gitCommit(repositoryName: String) {
+    val git = Git.open(File("$basePath/$repositoryName"))
+
+    git.add().addFilepattern(".").call()
+
+    git.commit()
+        .setMessage("Publish ${LibraryConfig.name} ${project.version}")
+        .call()
+}
+
+fun gitPush(repositoryName: String) {
+    val git = Git.open(File("$basePath/$repositoryName"))
+
+    val results: Iterable<PushResult> = git.push()
+        .setCredentialsProvider(UsernamePasswordCredentialsProvider(gitHubToken, ""))
+        .call()
+
+    results.forEach { result ->
+        (result.remoteUpdates as Collection<RemoteRefUpdate>).forEach { update ->
+            if (
+                update.status == RemoteRefUpdate.Status.REJECTED_NONFASTFORWARD
+                || update.status == RemoteRefUpdate.Status.REJECTED_REMOTE_CHANGED
+                || update.status == RemoteRefUpdate.Status.REJECTED_NODELETE
+                || update.status == RemoteRefUpdate.Status.REJECTED_OTHER_REASON
+            ) {
+                println(update.status)
+                throw IllegalStateException("Remote advanced! Please update first")
+            }
+        }
+    }
 }

--- a/buildSrc/src/main/kotlin/scripts/quality-spotless.gradle.kts
+++ b/buildSrc/src/main/kotlin/scripts/quality-spotless.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021. D4L data4life gGmbH / All rights reserved.
+ * Copyright (c) 2021 D4L data4life gGmbH / All rights reserved.
  *
  * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
  * including any intellectual property rights that subsist in the SDK.
@@ -20,27 +20,34 @@ package scripts
  * You need to add following dependencies to the buildSrc/build.gradle.kts
  *
  * - implementation("com.diffplug.spotless:spotless-plugin-gradle:5.10.2")
- * - implementation("com.pinterest:ktlint:0.40.0")
+ * - implementation("com.pinterest:ktlint:0.41.0")
  *
  */
 plugins {
     id("com.diffplug.spotless")
 }
 
+val ktlintVersion = "0.41.0"
+
 spotless {
     ratchetFrom("origin/main")
 
     kotlin {
         target("**/*.kt")
-        targetExclude("buildSrc/build/")
-        ktlint("0.40.0")
+        targetExclude("buildSrc/build/", "**/buildSrc/build/")
+        ktlint(ktlintVersion).userData(
+            mapOf(
+                "disabled_rules" to "no-wildcard-imports",
+                "ij_kotlin_imports_layout" to "*"
+            )
+        )
         trimTrailingWhitespace()
         indentWithSpaces()
         endWithNewline()
     }
     kotlinGradle {
         target("*.gradle.kts")
-        ktlint("0.40.0")
+        ktlint(ktlintVersion)
         trimTrailingWhitespace()
         indentWithSpaces()
         endWithNewline()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Description
To reduce the bottleneck of only one maven repository. This change will split publishing into:
* [maven-releases](https://github.com/d4l-data4life/maven-releases)
* [maven-snapshots](https://github.com/d4l-data4life/maven-snapshots)
* [maven-features](https://github.com/d4l-data4life/maven-features)

and remove use of [maven-repository](https://github.com/d4l-data4life/maven-repository)

### Bumped

* Gradle 6.7.1 -> 6.8.3
* Android Studio 4.1.1 -> 4.1.3

## Motivation and Context

Current solution was slow as it had to download the whole maven-repository and it also produced race conditions between publishing a feature and latest version at the same time, leading to first wins -> second fails.

## How is it being implemented?

The [Gradle Git publish plugin](https://github.com/d4l-data4life/gradle-git-publish) is replaced by a custom implementation using [jGit](https://www.eclipse.org/jgit/).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the changelog accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
